### PR TITLE
Fixes and improvements

### DIFF
--- a/Console/Command/GraphShell.php
+++ b/Console/Command/GraphShell.php
@@ -9,7 +9,7 @@ use phpDocumentor\GraphViz\Graph;
 use phpDocumentor\GraphViz\Node;
 
 /**
- * CakePHP GraphViz Models
+ * CakePHP GraphViz Relations
  *
  * This shell examines all models in the current application and its plugins,
  * finds all relations between them, and then generates a graphical representation
@@ -18,7 +18,7 @@ use phpDocumentor\GraphViz\Node;
  * <b>Usage:</b>
  *
  * <code>
- * $ Console/cake GraphViz.graph [filename] [format]
+ * $ Console/cake GraphVizRelations.graph [filename] [format]
  * </code>
  *
  * <b>Parameters:</b>
@@ -27,9 +27,8 @@ use phpDocumentor\GraphViz\Node;
  *              TMP folder will be used
  * * format - an optional output format, supported by GraphViz (png, svg, etc)
  *
- * @package app
- * @subpackage Utils
  * @author Leonid Mamchenkov <leonid@mamchenkov.net>
+ * @author Mark Scherer
  * @version 2.1 (Angry Blue Octopus On Steroids)
  */
 class GraphShell extends AppShell {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-CakePHP GraphViz Models
+CakePHP GraphViz Relations
 -----------------------
 
 This is a CakePHP shell that will find all models in your CakePHP application and
@@ -33,7 +33,7 @@ Usage
 The simplest way to use this shell is just to run it via CakePHP console:
 
 ```
-$ Console/cake GraphViz.graph
+$ Console/cake GraphVizRelations.graph
 ```
 
 This should generate a graph.png image in your current directory.  Please have a look.
@@ -42,13 +42,13 @@ If you need more control, there are two options that this shell understand from 
 command line: filename and format.   You can use either the filename option like so:
 
 ```
-$ Console/cake GraphViz.graph /tmp/my_models.png
+$ Console/cake GraphVizRelations.graph /tmp/my_models.png
 ```
 
 Or you can use both options together like so:
 
 ```
-$ Console/cake GraphViz.graph /tmp/my_models.svg svg
+$ Console/cake GraphVizRelations.graph /tmp/my_models.svg svg
 ```
 
 No special magic is done about the filename.  What You Give Is What You Get.  As for the

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,6 @@
 		"classmap": ["Console/Command/GraphShell.php"]
 	},
 	"extra": {
-		"installer-name": "GraphViz"
+		"installer-name": "GraphVizRelations"
 	}
 }


### PR DESCRIPTION
Relies on https://github.com/phpDocumentor/GraphViz/pull/10 being merged first for path to have any effect. Then it works on Windows - flawlessly :)
But also without the path being manually adjustable, this already works quite well now in 2.x.

Also
- Added Configure config approach
- Defaults to TMP as storing folder
- Excluded AppModels and some known Debugging/Setup plugins
- Folder simplified to "GraphViz"
- Corrected readme
- CS fixes and minor code improvements.
